### PR TITLE
Problem: Direct message type is not needed

### DIFF
--- a/api/dafka_proto.api
+++ b/api/dafka_proto.api
@@ -20,9 +20,6 @@
     <constant name = "fetch" value = "'F'" >
 
     </constant>
-    <constant name = "direct" value = "'D'" >
-
-    </constant>
     <constant name = "ack" value = "'K'" >
 
     </constant>
@@ -120,6 +117,14 @@
     <return type = "string" />
 </method>
 
+<method name = "subject">
+    Get the subject field
+    <return type = "string" />
+</method>
+<method name = "set subject">
+    Set the subject field
+    <argument name = "subject" type = "string" />
+</method>
 <method name = "address">
     Get the address field
     <return type = "string" />
@@ -147,14 +152,6 @@
     Set the content field, transferring ownership from caller
 <method name = "set content">
     <argument name = "content_p" type = "zframe" by_reference = "1" />
-</method>
-<method name = "subject">
-    Get the subject field
-    <return type = "string" />
-</method>
-<method name = "set subject">
-    Set the subject field
-    <argument name = "subject" type = "string" />
 </method>
 <method name = "count">
     Get the count field

--- a/include/dafka_proto.h
+++ b/include/dafka_proto.h
@@ -25,7 +25,6 @@ extern "C" {
 //  is provided in stable builds.
 #define DAFKA_PROTO_MSG 'M'                  //
 #define DAFKA_PROTO_FETCH 'F'                //
-#define DAFKA_PROTO_DIRECT 'D'               //
 #define DAFKA_PROTO_ACK 'K'                  //
 #define DAFKA_PROTO_HEAD 'H'                 //
 
@@ -100,6 +99,14 @@ DAFKA_EXPORT void
 DAFKA_EXPORT const char *
     dafka_proto_command (dafka_proto_t *self);
 
+//  Get the subject field
+DAFKA_EXPORT const char *
+    dafka_proto_subject (dafka_proto_t *self);
+
+//  Set the subject field
+DAFKA_EXPORT void
+    dafka_proto_set_subject (dafka_proto_t *self, const char *subject);
+
 //  Get the address field
 DAFKA_EXPORT const char *
     dafka_proto_address (dafka_proto_t *self);
@@ -127,14 +134,6 @@ DAFKA_EXPORT zframe_t *
 //
 DAFKA_EXPORT void
     dafka_proto_set_content (dafka_proto_t *self, zframe_t **content_p);
-
-//  Get the subject field
-DAFKA_EXPORT const char *
-    dafka_proto_subject (dafka_proto_t *self);
-
-//  Set the subject field
-DAFKA_EXPORT void
-    dafka_proto_set_subject (dafka_proto_t *self, const char *subject);
 
 //  Get the count field
 DAFKA_EXPORT uint32_t

--- a/src/dafka_proto.bnf
+++ b/src/dafka_proto.bnf
@@ -1,11 +1,13 @@
 The following ABNF grammar defines the dafka_proto:
 
-    dafka_proto     = *( MSG | FETCH | DIRECT | ACK | HEAD )
+    dafka_proto     = *( MSG | FETCH | ACK | HEAD )
 
-    ;  Message from producer to consumers. The topic is the message subject.
+    ;  Message from producer to consumers. The topic is either the subject or
+    ;  recipient address.
 
-    MSG             = signature %d'm' address sequence content
+    MSG             = signature %d'm' subject address sequence content
     signature       = %xAA %xA0             ; two octets
+    subject         = string                ;
     address         = string                ;
     sequence        = number-8              ;
     content         = frame                 ;
@@ -20,15 +22,6 @@ The following ABNF grammar defines the dafka_proto:
     count           = number-4              ;
     address         = string                ;
 
-    ;  Direct message to an address. Currently it is a response for the fetch
-    ;  message. Topic is the address of the recipient.
-
-    DIRECT          = signature %d'd' subject address sequence content
-    subject         = string                ;
-    address         = string                ;
-    sequence        = number-8              ;
-    content         = frame                 ;
-
     ;  Ack from a store daemon to a producer. Topic is the address of the
     ;  producer.
 
@@ -38,7 +31,8 @@ The following ABNF grammar defines the dafka_proto:
 
     ;  No description
 
-    HEAD            = signature %d'h' address sequence
+    HEAD            = signature %d'h' subject address sequence
+    subject         = string                ;
     address         = string                ;
     sequence        = number-8              ;
 

--- a/src/dafka_proto.xml
+++ b/src/dafka_proto.xml
@@ -11,8 +11,9 @@
 
     <message name = "MSG" id="'M'">
         Message from producer to consumers.
-        The topic is the message subject.
+        The topic is either the subject or recipient address.
 
+        <field name = "subject" type = "string" />
         <field name = "address" type = "string" />
         <field name = "sequence" type = "number" size = "8" />
         <field name = "content" type = "frame" />
@@ -29,17 +30,6 @@
         <field name = "address" type = "string" />
     </message>
 
-    <message name = "DIRECT" id = "'D'">
-        Direct message to an address.
-        Currently it is a response for the fetch message.
-        Topic is the address of the recipient.
-
-        <field name = "subject" type = "string" />
-        <field name = "address" type = "string" />
-        <field name = "sequence" type = "number" size = "8" />
-        <field name = "content" type = "frame" />
-    </message>
-
     <message name = "ACK" id = "'K'">
         Ack from a store daemon to a producer.
         Topic is the address of the producer.
@@ -49,6 +39,7 @@
     </message>
 
     <message name = "HEAD" id = "'H'">
+        <field name = "subject" type = "string" />
         <field name = "address" type = "string" />
         <field name = "sequence" type = "number" size = "8" />
     </message>

--- a/src/dafka_publisher.c
+++ b/src/dafka_publisher.c
@@ -74,6 +74,7 @@ dafka_publisher_new (zsock_t *pipe, dafka_publisher_args_t *args)
     self->msg = dafka_proto_new ();
     dafka_proto_set_id (self->msg, DAFKA_PROTO_MSG);
     dafka_proto_set_topic (self->msg, args->topic);
+    dafka_proto_set_subject (self->msg, args->topic);
     zuuid_t *address = zuuid_new ();
     dafka_proto_set_address (self->msg, zuuid_str (address));
     dafka_proto_set_sequence (self->msg, -1);
@@ -81,6 +82,7 @@ dafka_publisher_new (zsock_t *pipe, dafka_publisher_args_t *args)
     self->head_msg = dafka_proto_new ();
     dafka_proto_set_id (self->head_msg, DAFKA_PROTO_HEAD);
     dafka_proto_set_topic (self->head_msg, args->topic);
+    dafka_proto_set_subject (self->head_msg, args->topic);
     dafka_proto_set_address (self->head_msg, zuuid_str (address));
 
     self->beacon = zactor_new (dafka_beacon_actor, args->config);

--- a/src/dafka_store.c
+++ b/src/dafka_store.c
@@ -224,7 +224,7 @@ dafka_store_recv_sub (dafka_store_t *self) {
 
     switch (dafka_proto_id (self->income_msg)) {
         case DAFKA_PROTO_MSG: {
-            const char *subject = dafka_proto_topic (self->income_msg);
+            const char *subject = dafka_proto_subject (self->income_msg);
             const char *address = dafka_proto_address (self->income_msg);
             uint64_t sequence = dafka_proto_sequence (self->income_msg);
 
@@ -252,7 +252,7 @@ dafka_store_recv_sub (dafka_store_t *self) {
             dafka_proto_set_topic (self->outgoing_msg, dafka_proto_address (self->income_msg));
             dafka_proto_set_subject (self->outgoing_msg, subject);
             dafka_proto_set_address (self->outgoing_msg, address);
-            dafka_proto_set_id (self->outgoing_msg, DAFKA_PROTO_DIRECT);
+            dafka_proto_set_id (self->outgoing_msg, DAFKA_PROTO_MSG);
 
             for (uint32_t i = 0; i < count; i++) {
                 store_key_init (&key, subject, address, sequence + i);

--- a/src/dafka_subscriber.c
+++ b/src/dafka_subscriber.c
@@ -89,7 +89,7 @@ dafka_subscriber_new (zsock_t *pipe, zconfig_t *config)
     dafka_proto_set_id (self->fetch_msg, DAFKA_PROTO_FETCH);
     zuuid_t *consumer_address = zuuid_new ();
     dafka_proto_set_address (self->fetch_msg, zuuid_str (consumer_address));
-    dafka_proto_subscribe (self->consumer_sub, DAFKA_PROTO_DIRECT, zuuid_str (consumer_address));
+    dafka_proto_subscribe (self->consumer_sub, DAFKA_PROTO_MSG, zuuid_str (consumer_address));
     zuuid_destroy(&consumer_address);
 
     self->beacon = zactor_new (dafka_beacon_actor, config);
@@ -161,17 +161,12 @@ dafka_subscriber_recv_subscriptions (dafka_subscriber_t *self)
     const char *subject;
     if (id == DAFKA_PROTO_MSG) {
         address = dafka_proto_address (self->consumer_msg);
-        subject = dafka_proto_topic (self->consumer_msg);
-    }
-    else
-    if (id == DAFKA_PROTO_DIRECT) {
-        address = dafka_proto_address (self->consumer_msg);
         subject = dafka_proto_subject (self->consumer_msg);
     }
     else
     if (id == DAFKA_PROTO_HEAD) {
         address = dafka_proto_address (self->consumer_msg);
-        subject = dafka_proto_topic (self->consumer_msg);
+        subject = dafka_proto_subject (self->consumer_msg);
     }
     else
         return;     // Unexpected message id
@@ -209,7 +204,7 @@ dafka_subscriber_recv_subscriptions (dafka_subscriber_t *self)
         dafka_proto_send (self->fetch_msg, self->consumer_pub);
     }
 
-    if (id == DAFKA_PROTO_MSG || id == DAFKA_PROTO_DIRECT) {
+    if (id == DAFKA_PROTO_MSG) {
         if (msg_sequence == last_known_sequence + 1) {
             if (self->verbose)
                 zsys_debug ("Send message %u to client", msg_sequence);


### PR DESCRIPTION
Also, different type for direct messaging will cause us to duplicate alot of message types

Solution: MSG & HEAD can both direct and a broadcast, depending on the TOPIC. Adding subject to both messages, as topic should not be used as subject now.