### PR TITLE
Problem: Wrongfully assume that trusty is ubuntu 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ os:
 - linux
 - osx
 
-dist: trusty
+dist: xenial
 
 sudo: false
 


### PR DESCRIPTION
Solution: Use the correct alias xenial