### PR TITLE
Problem: Publisher forgets about send messages immediately

### DIFF
--- a/include/dafka.h
+++ b/include/dafka.h
@@ -19,4 +19,48 @@
 
 //  Add your own public definitions here, if you need them
 
+//  Static helper methods
+
+static void
+uint64_destroy (void **item_p)
+{
+    assert (item_p);
+    if (*item_p) {
+        uint64_t *item = (uint64_t *) *item_p;
+        free (item);
+        *item_p = NULL;
+    }
+}
+
+static void *
+uint64_dup (const void *item)
+{
+    uint64_t *value = (uint64_t *) malloc (sizeof (uint64_t));
+    memcpy (value, item, sizeof (uint64_t));
+    return value;
+}
+
+static int
+uint64_cmp (const void *item1, const void *item2)
+{
+    uint64_t value1 = *((uint64_t *) item1);
+    uint64_t value2 = *((uint64_t *) item2);
+    if (value1 < value2)
+        return -1;
+    else
+    if (value1 == value2)
+        return 0;
+    else
+    if (value1 > value2)
+        return 1;
+}
+
+static size_t
+uint64_hash (const void *item)
+{
+    uint64_t value = *((uint64_t *) item);
+    return (size_t) value;
+}
+
+
 #endif

--- a/src/dafka_publisher.c
+++ b/src/dafka_publisher.c
@@ -314,7 +314,7 @@ dafka_publisher_publish (zactor_t *self, zframe_t **content) {
     int rc = zstr_sendm (self, "PUBLISH");
 
     if (rc == -1) {
-        zframe_destroy (&content);
+        zframe_destroy (content);
         *content = NULL;
         return rc;
     }

--- a/src/dafka_subscriber.c
+++ b/src/dafka_subscriber.c
@@ -42,25 +42,6 @@ struct _dafka_subscriber_t {
     zactor_t* beacon;           // Beacon actor
 };
 
-//  Static helper methods
-
-static void
-uint64_destroy (void **self_p) {
-    assert (self_p);
-    if (*self_p) {
-        uint64_t *self = *self_p;
-        free (self);
-        *self_p = NULL;
-    }
-}
-
-static void *
-uint64_dup (const void *self) {
-    uint64_t *value = malloc(sizeof (uint64_t));
-    memcpy (value, self, sizeof (uint64_t));
-    return value;
-}
-
 //  --------------------------------------------------------------------------
 //  Create a new dafka_subscriber instance
 


### PR DESCRIPTION
Solution: Cache the send messages until a ACK is received and repeat
messages that have not been acked at a regular interval.