### PR TITLE
Problem: Consumer always reads a partition from sequence 0

### DIFF
--- a/src/dafka_console_consumer.c
+++ b/src/dafka_console_consumer.c
@@ -27,7 +27,7 @@ int main (int argc, char *argv [])
     zargs_t *args = zargs_new (argc, argv);
 
     if (zargs_hasx (args, "--help", "-h", NULL) || zargs_arguments (args) != 1) {
-        puts ("Usage: dafka_console_consumer [--verbose] [-c config] [--pub tower-pub-address] [--sub tower-sub-address] topic");
+        puts ("Usage: dafka_console_consumer [--verbose] [--from-beginning] [-c config] [--pub tower-pub-address] [--sub tower-sub-address] topic");
         return 0;
     }
 
@@ -42,6 +42,9 @@ int main (int argc, char *argv [])
         zconfig_put (config, "beacon/verbose", "1");
         zconfig_put (config, "consumer/verbose", "1");
     }
+
+    if (zargs_has (args, "--from-beginning"))
+        zconfig_put (config, "consumer/offset/reset", "earliest");
 
     if (zargs_has (args, "--pub"))
         zconfig_put (config, "beacon/pub_address", zargs_get (args, "--pub"));

--- a/src/dafka_store.c
+++ b/src/dafka_store.c
@@ -410,6 +410,7 @@ dafka_store_test (bool verbose)
     zconfig_put (config, "tower/pub_address","inproc://store-tower-pub");
     zconfig_put (config, "store/verbose", verbose ? "1" : "0");
     zconfig_put (config, "store/db", SELFTEST_DIR_RW "/storedb");
+    zconfig_put (config, "consumer/offset/reset", "earliest");
 
     // Creating the store
     zactor_t *tower = zactor_new (dafka_tower_actor, config);


### PR DESCRIPTION
Solution: Introduce the offset reset configuration which can be either
earliest or latest. Earliest is the current behaviour and reads
partitions always from sequence 0. Latest is the new default and reads
partitions from the current sequence received by a MSG or HEAD.