### PR TITLE
Problem: store is using one thread for both writing and reading

### DIFF
--- a/src/dafka_beacon.c
+++ b/src/dafka_beacon.c
@@ -229,7 +229,7 @@ dafka_beacon_recv_sub (dafka_beacon_t *self) {
         zsock_recv (self->sub, "ss", &sender, &address);
 
         // Drop our own beaconing
-        if (strneq (self->sender, sender)) {
+        if (self->sender == NULL || strneq (self->sender, sender)) {
             int64_t* expire = (int64_t *)  zhashx_lookup (self->peers, address);
 
             if (expire == NULL) {

--- a/src/dafka_util.c
+++ b/src/dafka_util.c
@@ -60,3 +60,38 @@ uint64_hash (const void *item)
     return (size_t) value;
 }
 
+char *
+generate_address () {
+    zuuid_t *uuid = zuuid_new ();
+    char *address = strdup (zuuid_str (uuid));
+    zuuid_destroy (&uuid);
+    return address;
+}
+
+size_t
+uint64_put_le (byte* output, uint64_t value) {
+    output[7] = (byte) (((value) >> 56) & 255);
+    output[6] = (byte) (((value) >> 48) & 255);
+    output[5] = (byte) (((value) >> 40) & 255);
+    output[4] = (byte) (((value) >> 32) & 255);
+    output[3] = (byte) (((value) >> 24) & 255);
+    output[2] = (byte) (((value) >> 16) & 255);
+    output[1] = (byte) (((value) >> 8) & 255);
+    output[0] = (byte) (((value)) & 255);
+
+    return 8;
+}
+
+size_t
+uint64_get_le (const byte* input, uint64_t *value) {
+    *value =  ((uint64_t) (input [7]) << 56)
+           + ((uint64_t) (input [6]) << 48)
+           + ((uint64_t) (input [5]) << 40)
+           + ((uint64_t) (input [4]) << 32)
+           + ((uint64_t) (input [3]) << 24)
+           + ((uint64_t) (input [2]) << 16)
+           + ((uint64_t) (input [1]) << 8)
+           +  (uint64_t) (input [0]);
+
+    return 8;
+}

--- a/src/dafka_util.h
+++ b/src/dafka_util.h
@@ -18,6 +18,8 @@
 extern "C" {
 #endif
 
+DAFKA_PRIVATE char *
+generate_address ();
 
 DAFKA_PRIVATE void
 uint64_destroy (void **item_p);
@@ -30,6 +32,13 @@ uint64_cmp (const void *item1, const void *item2);
 
 DAFKA_PRIVATE size_t
 uint64_hash (const void *item);
+
+DAFKA_PRIVATE size_t
+uint64_put_le (byte* output, uint64_t value);
+
+DAFKA_PRIVATE size_t
+uint64_get_le (const byte* input, uint64_t *value);
+
 
 //  @end
 


### PR DESCRIPTION
which is very slow and make consumer wait for writing to complete.
Also we are not utilizing leveldb primitives like batch writing and iterating

Solution: separate store into write and read actors which use the same underlying leveldb.

Store is using batch for writing (up to 1000) and only ack the last message per subject/address of a batch