### PR TITLE
Problem: Console consumer publishes messages before store is connected

### DIFF
--- a/src/dafka_console_consumer.c
+++ b/src/dafka_console_consumer.c
@@ -57,6 +57,9 @@ int main (int argc, char *argv [])
     zactor_t *consumer = zactor_new (dafka_consumer, config);
     assert (consumer);
 
+    // Give time until connected to pubs and stores
+    usleep (500);
+
     int rc = dafka_consumer_subscribe (consumer, topic);
     assert (rc == 0);
 


### PR DESCRIPTION
Workaround: Wait 500ms until connected to pubs and stores before sending
subscribe request.

!! This code can be removed once the consumer send an EARLIEST message
itself whenever a store connects.