### PR TITLE
problem: repeating fetch messages deny a subscriber from ever catching up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(dafka)
 enable_language(C)
 enable_testing()
@@ -74,7 +74,7 @@ endif()
 
 file(REMOVE "${SOURCE_DIR}/src/platform.h")
 
-file(WRITE "${CMAKE_BINARY_DIR}/platform.h.in" "
+file(WRITE "${PROJECT_BINARY_DIR}/platform.h.in" "
 #cmakedefine HAVE_LINUX_WIRELESS_H
 #cmakedefine HAVE_NET_IF_H
 #cmakedefine HAVE_NET_IF_MEDIA_H
@@ -82,7 +82,7 @@ file(WRITE "${CMAKE_BINARY_DIR}/platform.h.in" "
 #cmakedefine HAVE_FREEIFADDRS
 ")
 
-configure_file("${CMAKE_BINARY_DIR}/platform.h.in" "${CMAKE_BINARY_DIR}/platform.h")
+configure_file("${PROJECT_BINARY_DIR}/platform.h.in" "${PROJECT_BINARY_DIR}/platform.h")
 
 #The MSVC C compiler is too out of date,
 #so the sources have to be compiled as c++
@@ -192,6 +192,7 @@ set (dafka_headers
     include/dafka_beacon.h
     include/dafka_tower.h
     include/dafka_store.h
+    src/dafka_fetch_filter.h
     src/dafka_msg_key.h
     src/dafka_head_key.h
     src/dafka_util.h
@@ -207,8 +208,9 @@ install(FILES ${dafka_headers} DESTINATION include)
 ########################################################################
 
 
-include_directories("${SOURCE_DIR}/src" "${SOURCE_DIR}/include" "${CMAKE_BINARY_DIR}")
+include_directories("${SOURCE_DIR}/src" "${SOURCE_DIR}/include" "${PROJECT_BINARY_DIR}")
 set (dafka_sources
+    src/dafka_fetch_filter.c
     src/dafka_msg_key.c
     src/dafka_head_key.c
     src/dafka_consumer_msg.c
@@ -248,11 +250,15 @@ ENDIF (NOT MSVC)
 
 # shared
 if (DAFKA_BUILD_SHARED)
-  IF (MSVC)
+  IF (APPLE)
     add_library(dafka SHARED ${dafka_sources})
-  ELSE (MSVC)
-    add_library(dafka SHARED $<TARGET_OBJECTS:dafka_objects>)
-  ENDIF (MSVC)
+  ELSE (APPLE)
+    IF (MSVC)
+      add_library(dafka SHARED ${dafka_sources})
+    ELSE (MSVC)
+      add_library(dafka SHARED $<TARGET_OBJECTS:dafka_objects>)
+    ENDIF (MSVC)
+  ENDIF(APPLE)
 
   set_target_properties (dafka PROPERTIES
     PUBLIC_HEADER "${public_headers}"
@@ -284,11 +290,15 @@ endif()
 
 # static
 if (DAFKA_BUILD_STATIC)
-  IF (MSVC)
+  IF (APPLE)
     add_library(dafka-static STATIC ${dafka_sources})
-  ELSE (MSVC)
-    add_library(dafka-static STATIC $<TARGET_OBJECTS:dafka_objects>)
-  ENDIF (MSVC)
+  ELSE (APPLE)
+    IF (MSVC)
+      add_library(dafka-static STATIC ${dafka_sources})
+    ELSE (MSVC)
+      add_library(dafka-static STATIC $<TARGET_OBJECTS:dafka_objects>)
+    ENDIF (MSVC)
+  ENDIF (APPLE)
 
   set_target_properties(dafka-static PROPERTIES
     PUBLIC_HEADER "${public_headers}"
@@ -571,17 +581,17 @@ ENDIF (ENABLE_DRAFTS)
 
 add_custom_target(
     copy-selftest-ro ALL
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/src/selftest-ro ${CMAKE_BINARY_DIR}/src/selftest-ro
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/src/selftest-ro ${PROJECT_BINARY_DIR}/src/selftest-ro
 )
 
 add_custom_target(
     make-selftest-rw ALL
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/src/selftest-rw
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/src/selftest-rw
 )
 
 set_directory_properties(
     PROPERTIES
-    ADDITIONAL_MAKE_CLEAN_FILES "${CMAKE_BINARY_DIR}/src/selftest-ro;${CMAKE_BINARY_DIR}/src/selftest-rw"
+    ADDITIONAL_MAKE_CLEAN_FILES "${PROJECT_BINARY_DIR}/src/selftest-ro;${PROJECT_BINARY_DIR}/src/selftest-rw"
 )
 
 foreach(TEST_CLASS ${TEST_CLASSES})
@@ -606,24 +616,24 @@ include(CTest)
 ########################################################################
 add_custom_target (distclean @echo Cleaning for source distribution)
 
-set(cmake_generated ${CMAKE_BINARY_DIR}/CMakeCache.txt
-                    ${CMAKE_BINARY_DIR}/cmake_install.cmake
-                    ${CMAKE_BINARY_DIR}/Makefile
-                    ${CMAKE_BINARY_DIR}/CMakeFiles
-                    ${CMAKE_BINARY_DIR}/CTestTestfile.cmake
-                    ${CMAKE_BINARY_DIR}/DartConfiguration.tcl
-                    ${CMAKE_BINARY_DIR}/Testing
-                    ${CMAKE_BINARY_DIR}/compile_commands.json
-                    ${CMAKE_BINARY_DIR}/platform.h
-                    ${CMAKE_BINARY_DIR}/src/libdafka.pc
-                    ${CMAKE_BINARY_DIR}/src/libdafka.so
-                    ${CMAKE_BINARY_DIR}/src/dafka_selftest
-                    ${CMAKE_BINARY_DIR}/src/dafka_console_producer
-                    ${CMAKE_BINARY_DIR}/src/dafka_console_consumer
-                    ${CMAKE_BINARY_DIR}/src/dafka_stored
-                    ${CMAKE_BINARY_DIR}/src/dafka_towerd
-                    ${CMAKE_BINARY_DIR}/src/dafka_perf_store
-                    ${CMAKE_BINARY_DIR}/src/dafka_selftest
+set(cmake_generated ${PROJECT_BINARY_DIR}/CMakeCache.txt
+                    ${PROJECT_BINARY_DIR}/cmake_install.cmake
+                    ${PROJECT_BINARY_DIR}/Makefile
+                    ${PROJECT_BINARY_DIR}/CMakeFiles
+                    ${PROJECT_BINARY_DIR}/CTestTestfile.cmake
+                    ${PROJECT_BINARY_DIR}/DartConfiguration.tcl
+                    ${PROJECT_BINARY_DIR}/Testing
+                    ${PROJECT_BINARY_DIR}/compile_commands.json
+                    ${PROJECT_BINARY_DIR}/platform.h
+                    ${PROJECT_BINARY_DIR}/src/libdafka.pc
+                    ${PROJECT_BINARY_DIR}/src/libdafka.so
+                    ${PROJECT_BINARY_DIR}/src/dafka_selftest
+                    ${PROJECT_BINARY_DIR}/src/dafka_console_producer
+                    ${PROJECT_BINARY_DIR}/src/dafka_console_consumer
+                    ${PROJECT_BINARY_DIR}/src/dafka_stored
+                    ${PROJECT_BINARY_DIR}/src/dafka_towerd
+                    ${PROJECT_BINARY_DIR}/src/dafka_perf_store
+                    ${PROJECT_BINARY_DIR}/src/dafka_selftest
 )
 
 add_custom_command(

--- a/Findczmq.cmake
+++ b/Findczmq.cmake
@@ -25,7 +25,7 @@ find_path (
 
 find_library (
     CZMQ_LIBRARIES
-    NAMES czmq
+    NAMES libczmq czmq
     HINTS ${PC_CZMQ_LIBRARY_HINTS}
 )
 

--- a/Findlibzmq.cmake
+++ b/Findlibzmq.cmake
@@ -23,11 +23,60 @@ find_path (
     HINTS ${PC_LIBZMQ_INCLUDE_HINTS}
 )
 
-find_library (
-    LIBZMQ_LIBRARIES
-    NAMES zmq
-    HINTS ${PC_LIBZMQ_LIBRARY_HINTS}
-)
+if (MSVC)
+    # libzmq dll/lib built with MSVC is named using the Boost convention.
+    # https://github.com/zeromq/czmq/issues/577
+    # https://github.com/zeromq/czmq/issues/1972
+    if (MSVC_IDE)
+        set(MSVC_TOOLSET "-${CMAKE_VS_PLATFORM_TOOLSET}")
+    else ()
+        set(MSVC_TOOLSET "")
+    endif ()
+
+    # Retrieve ZeroMQ version number from zmq.h
+    file(STRINGS "${LIBZMQ_INCLUDE_DIRS}/zmq.h" zmq_version_defines
+        REGEX "#define ZMQ_VERSION_(MAJOR|MINOR|PATCH)")
+    foreach(ver ${zmq_version_defines})
+        if(ver MATCHES "#define ZMQ_VERSION_(MAJOR|MINOR|PATCH) +([^ ]+)$")
+            set(ZMQ_VERSION_${CMAKE_MATCH_1} "${CMAKE_MATCH_2}" CACHE INTERNAL "")
+        endif()
+    endforeach()
+
+    set(_zmq_version ${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH})
+
+    set(_zmq_debug_names
+        "libzmq${MSVC_TOOLSET}-mt-gd-${_zmq_version}" # Debug, BUILD_SHARED
+        "libzmq${MSVC_TOOLSET}-mt-sgd-${_zmq_version}" # Debug, BUILD_STATIC
+        "libzmq-mt-gd-${_zmq_version}" # Debug, BUILD_SHARED
+        "libzmq-mt-sgd-${_zmq_version}" # Debug, BUILD_STATIC
+    )
+
+    set(_zmq_release_names
+        "libzmq${MSVC_TOOLSET}-mt-${_zmq_version}" # Release|RelWithDebInfo|MinSizeRel, BUILD_SHARED
+        "libzmq${MSVC_TOOLSET}-mt-s-${_zmq_version}" # Release|RelWithDebInfo|MinSizeRel, BUILD_STATIC
+        "libzmq-mt-${_zmq_version}" # Release|RelWithDebInfo|MinSizeRel, BUILD_SHARED
+        "libzmq-mt-s-${_zmq_version}" # Release|RelWithDebInfo|MinSizeRel, BUILD_STATIC
+    )
+
+    find_library (LIBZMQ_LIBRARY_DEBUG
+        NAMES ${_zmq_debug_names}
+    )
+
+    find_library (LIBZMQ_LIBRARY_RELEASE
+        NAMES ${_zmq_release_names}
+    )
+
+    include(SelectLibraryConfigurations)
+    select_library_configurations(LIBZMQ)
+endif ()
+
+if (NOT LIBZMQ_LIBRARIES)
+    find_library (
+        LIBZMQ_LIBRARIES
+        NAMES libzmq zmq
+        HINTS ${PC_LIBZMQ_LIBRARY_HINTS}
+    )
+endif ()
 
 include(FindPackageHandleStandardArgs)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -43,6 +43,7 @@ EXTRA_DIST += \
 endif
 
 EXTRA_DIST += \
+    src/dafka_fetch_filter.h \
     src/dafka_msg_key.h \
     src/dafka_head_key.h \
     src/dafka_util.h \

--- a/builds/cmake/Modules/ClangFormat.cmake
+++ b/builds/cmake/Modules/ClangFormat.cmake
@@ -3,15 +3,15 @@
 # get all project files
 file(GLOB_RECURSE ALL_SOURCE_FILES
      RELATIVE ${CMAKE_CURRENT_BINARY_DIR}
-     ${CMAKE_SOURCE_DIR}/src/*.c ${CMAKE_SOURCE_DIR}/src/*.cc ${CMAKE_SOURCE_DIR}/src/*.cpp
-     ${CMAKE_SOURCE_DIR}/src/*.h ${CMAKE_SOURCE_DIR}/src/*.hpp
-     ${CMAKE_SOURCE_DIR}/tests/*.c ${CMAKE_SOURCE_DIR}/tests/*.cc ${CMAKE_SOURCE_DIR}/tests/*.cpp
-     ${CMAKE_SOURCE_DIR}/tests/*.h ${CMAKE_SOURCE_DIR}/tests/*.hpp
-     ${CMAKE_SOURCE_DIR}/perf/*.c ${CMAKE_SOURCE_DIR}/perf/*.cc ${CMAKE_SOURCE_DIR}/perf/*.cpp
-     ${CMAKE_SOURCE_DIR}/perf/*.h ${CMAKE_SOURCE_DIR}/perf/*.hpp
-     ${CMAKE_SOURCE_DIR}/tools/*.c ${CMAKE_SOURCE_DIR}/tools/*.cc ${CMAKE_SOURCE_DIR}/tools/*.cpp
-     ${CMAKE_SOURCE_DIR}/tools/*.h ${CMAKE_SOURCE_DIR}/tools/*.hpp
-     ${CMAKE_SOURCE_DIR}/include/*.h ${CMAKE_SOURCE_DIR}/include/*.hpp
+     ${PROJECT_SOURCE_DIR}/src/*.c ${PROJECT_SOURCE_DIR}/src/*.cc ${PROJECT_SOURCE_DIR}/src/*.cpp
+     ${PROJECT_SOURCE_DIR}/src/*.h ${PROJECT_SOURCE_DIR}/src/*.hpp
+     ${PROJECT_SOURCE_DIR}/tests/*.c ${PROJECT_SOURCE_DIR}/tests/*.cc ${PROJECT_SOURCE_DIR}/tests/*.cpp
+     ${PROJECT_SOURCE_DIR}/tests/*.h ${PROJECT_SOURCE_DIR}/tests/*.hpp
+     ${PROJECT_SOURCE_DIR}/perf/*.c ${PROJECT_SOURCE_DIR}/perf/*.cc ${PROJECT_SOURCE_DIR}/perf/*.cpp
+     ${PROJECT_SOURCE_DIR}/perf/*.h ${PROJECT_SOURCE_DIR}/perf/*.hpp
+     ${PROJECT_SOURCE_DIR}/tools/*.c ${PROJECT_SOURCE_DIR}/tools/*.cc ${PROJECT_SOURCE_DIR}/tools/*.cpp
+     ${PROJECT_SOURCE_DIR}/tools/*.h ${PROJECT_SOURCE_DIR}/tools/*.hpp
+     ${PROJECT_SOURCE_DIR}/include/*.h ${PROJECT_SOURCE_DIR}/include/*.hpp
     )
 
 if("${CLANG_FORMAT}" STREQUAL "")

--- a/project.xml
+++ b/project.xml
@@ -26,6 +26,7 @@
     <actor name = "dafka_store_writer" private = "1" selftest = "0" />
     <actor name = "dafka_store" state = "stable" />
 
+    <class name = "dafka_fetch_filter" private = "1" selftest = "0" />
     <class name = "dafka_msg_key" private = "1" selftest = "0" />
     <class name = "dafka_head_key" private = "1" selftest = "0" />
 

--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -13,6 +13,7 @@ lib_LTLIBRARIES += src/libdafka.la
 pkgconfig_DATA = src/libdafka.pc
 
 src_libdafka_la_SOURCES = \
+    src/dafka_fetch_filter.c \
     src/dafka_msg_key.c \
     src/dafka_head_key.c \
     src/dafka_consumer_msg.c \

--- a/src/dafka_classes.h
+++ b/src/dafka_classes.h
@@ -25,6 +25,10 @@
 #include "../include/dafka.h"
 
 //  Opaque class structures to allow forward references
+#ifndef DAFKA_FETCH_FILTER_T_DEFINED
+typedef struct _dafka_fetch_filter_t dafka_fetch_filter_t;
+#define DAFKA_FETCH_FILTER_T_DEFINED
+#endif
 #ifndef DAFKA_MSG_KEY_T_DEFINED
 typedef struct _dafka_msg_key_t dafka_msg_key_t;
 #define DAFKA_MSG_KEY_T_DEFINED
@@ -50,6 +54,7 @@ typedef struct _dafka_store_writer_t dafka_store_writer_t;
 
 //  Internal API
 
+#include "dafka_fetch_filter.h"
 #include "dafka_msg_key.h"
 #include "dafka_head_key.h"
 #include "dafka_util.h"

--- a/src/dafka_consumer.c
+++ b/src/dafka_consumer.c
@@ -68,7 +68,10 @@ dafka_consumer_new (zsock_t *pipe, zconfig_t *config) {
     if (atoi (zconfig_get (config, "consumer/verbose", "0")))
         self->verbose = true;
 
+    int hwm = atoi (zconfig_get (config, "consumer/high_watermark", "1000000"));
+
     self->consumer_sub = zsock_new_sub (NULL, NULL);
+    zsock_set_rcvhwm (self->consumer_sub, hwm);
     self->consumer_msg = dafka_proto_new ();
 
     self->sequence_index = zhashx_new ();
@@ -76,6 +79,7 @@ dafka_consumer_new (zsock_t *pipe, zconfig_t *config) {
     zhashx_set_duplicator (self->sequence_index, uint64_dup);
 
     self->consumer_pub = zsock_new_xpub (NULL);
+    zsock_set_sndhwm (self->consumer_pub, hwm);
     zsock_set_xpub_verbose (self->consumer_pub, 1);
     int port = zsock_bind (self->consumer_pub, "tcp://*:*");
     assert (port != -1);

--- a/src/dafka_fetch_filter.c
+++ b/src/dafka_fetch_filter.c
@@ -1,0 +1,133 @@
+/*  =========================================================================
+    dafka_fetch_filter - class description
+
+    Copyright (c) the Contributors as noted in the AUTHORS file.
+    This file is part of CZMQ, the high-level C binding for 0MQ:
+    http://czmq.zeromq.org.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    =========================================================================
+*/
+
+/*
+@header
+    dafka_fetch_filter -
+@discuss
+@end
+*/
+
+#include "dafka_classes.h"
+
+//  Structure of our class
+
+typedef struct {
+    char subject[256];
+    char address[256];
+    uint64_t sequence_hash;
+    uint64_t time_hash;
+} fetch_request_t;
+
+struct _dafka_fetch_filter_t {
+    zsock_t *publisher;
+    bool verbose;
+    int filter_size;
+    fetch_request_t *cache;
+    dafka_proto_t *msg;
+};
+
+
+//  --------------------------------------------------------------------------
+//  Create a new dafka_fetch_filter
+
+dafka_fetch_filter_t *
+dafka_fetch_filter_new (zsock_t *publisher, const char *address, bool verbose)
+{
+    dafka_fetch_filter_t *self = (dafka_fetch_filter_t *) zmalloc (sizeof (dafka_fetch_filter_t));
+    assert (self);
+
+    self->publisher = publisher;
+    self->filter_size = 10000;
+    self->cache = (fetch_request_t *) zmalloc (sizeof (fetch_request_t) * self->filter_size);
+    self->msg = dafka_proto_new ();
+    self->verbose = verbose;
+
+    dafka_proto_set_id (self->msg, DAFKA_PROTO_FETCH);
+    dafka_proto_set_address (self->msg, address);
+
+
+    //  Initialize class properties here
+    return self;
+}
+
+static uint64_t
+hash_string (const char *s)
+{
+    uint64_t hash = 0;
+    while (*s != '\0')
+        hash = 33 * hash ^ *s++;
+
+    return hash;
+}
+
+void
+dafka_fetch_filter_send (dafka_fetch_filter_t *self, const char *subject, const char *address, uint64_t sequence)
+{
+    int64_t time = zclock_mono ();
+    int max_count = 100000;
+
+    uint64_t sequence_hash = sequence / max_count;
+    uint64_t time_hash = (time / 1000);
+    int count = (sequence_hash + 1) * max_count - sequence;
+
+    uint64_t hash = hash_string(subject);
+    hash = 33 * hash ^ hash_string(address);
+    hash = 33 * hash ^ sequence_hash;
+    hash = 33 * hash ^ time_hash;
+    int index = hash % self->filter_size;
+
+    fetch_request_t *request = &self->cache[index];
+
+    if (sequence_hash == request->sequence_hash &&
+        time_hash == request->time_hash &&
+        streq (subject, request->subject) &&
+        streq (address, request->address)) {
+        if (self->verbose)
+            zsys_debug ("Filter: Filtered fetch request %s %s %" PRIu64, subject, address, sequence);
+    } else {
+        if (self->verbose)
+            zsys_debug ("Filter: Sending fetch request %s %s %" PRIu64, subject, address, sequence);
+
+        strncpy (request->subject, subject, 255);
+        strncpy (request->address, address, 255);
+        request->sequence_hash = sequence_hash;
+        request->time_hash = time_hash;
+
+        dafka_proto_set_topic (self->msg, address);
+        dafka_proto_set_subject (self->msg, subject);
+        dafka_proto_set_sequence (self->msg, sequence);
+        dafka_proto_set_count (self->msg, count);
+
+        dafka_proto_send (self->msg, self->publisher);
+    }
+}
+
+//  --------------------------------------------------------------------------
+//  Destroy the dafka_fetch_filter
+
+void
+dafka_fetch_filter_destroy (dafka_fetch_filter_t **self_p)
+{
+    assert (self_p);
+    if (*self_p) {
+        dafka_fetch_filter_t *self = *self_p;
+        //  Free class properties here
+        free (self->cache);
+        self->cache = NULL;
+        dafka_proto_destroy (&self->msg);
+        //  Free object itself
+        free (self);
+        *self_p = NULL;
+    }
+}

--- a/src/dafka_fetch_filter.h
+++ b/src/dafka_fetch_filter.h
@@ -1,0 +1,39 @@
+/*  =========================================================================
+    dafka_fetch_filter - class description
+
+    Copyright (c) the Contributors as noted in the AUTHORS file.
+    This file is part of CZMQ, the high-level C binding for 0MQ:
+    http://czmq.zeromq.org.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    =========================================================================
+*/
+
+#ifndef DAFKA_FETCH_FILTER_H_INCLUDED
+#define DAFKA_FETCH_FILTER_H_INCLUDED
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//  @interface
+//  Create a new dafka_fetch_filter
+DAFKA_PRIVATE dafka_fetch_filter_t *
+    dafka_fetch_filter_new (zsock_t *publisher, const char *address, bool verbose);
+
+DAFKA_PRIVATE void dafka_fetch_filter_send (dafka_fetch_filter_t *self, const char *subject, const char *address, uint64_t sequence);
+
+//  Destroy the dafka_fetch_filter
+DAFKA_PRIVATE void
+    dafka_fetch_filter_destroy (dafka_fetch_filter_t **self_p);
+
+
+//  @end
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/dafka_perf_store.c
+++ b/src/dafka_perf_store.c
@@ -81,7 +81,9 @@ void subscriber_actor (zsock_t *pipe, subscriber_args *args) {
 
 int main (int argc, char *argv [])
 {
-    zsys_set_sndhwm (100000);
+    zsys_set_sndhwm (1000000);
+    zsys_set_pipehwm (1000000);
+
 
     zargs_t *args = zargs_new (argc, argv);
 

--- a/src/dafka_producer.c
+++ b/src/dafka_producer.c
@@ -77,8 +77,12 @@ dafka_producer_new (zsock_t *pipe, dafka_producer_args_t *args)
 
     self->head_interval = atoi (zconfig_get (args->config, "producer/head_interval", "1000"));
 
+    int hwm = atoi (zconfig_get (args->config, "producer/high_watermark", "1000000"));
+
     self->socket = zsock_new_pub (NULL);
+    zsock_set_sndhwm (self->socket, hwm);
     self->producer_sub = zsock_new_sub (NULL, NULL);
+    zsock_set_rcvhwm (self->producer_sub, hwm);
     int port = zsock_bind (self->socket, "tcp://*:*");
     assert (self->socket);
 


### PR DESCRIPTION
Solution: add a filter which filters repeating fetch requests at the same second

Slow Subscriber will actually get full by getting the same messages all the time by sending the fetch requests for the same range. This PR fixes this by filtering fetch requests for the same range. 