### PR TITLE
Problem: Consumer uses same socket for sync commands and async records

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ To consume this message we constuct a dafka consumer, let it subscribe to topic 
 zconfig_t *config = zconfig_new ("root", NULL);
 const char *topic = "hello";
 
-zactor_t *consumer = zactor_new (dafka_consumer, config);
+dafka_consumer_t *consumer = dafka_consumer_new (config);
 dafka_consumer_subscribe (consumer, topic);
 
 dafka_consumer_msg_t *msg = dafka_consumer_msg_new ();
@@ -387,7 +387,7 @@ while (true) {
 }
 
 dafka_consumer_msg_destroy (&msg);
-zactor_destroy (&consumer);
+dafka_consumer_destroy (&consumer);
 zconfig_destroy (&config);
 ```
 

--- a/README.txt
+++ b/README.txt
@@ -457,7 +457,7 @@ To consume this message we constuct a dafka consumer, let it subscribe to topic 
 zconfig_t *config = zconfig_new ("root", NULL);
 const char *topic = "hello";
 
-zactor_t *consumer = zactor_new (dafka_consumer, config);
+dafka_consumer_t *consumer = dafka_consumer_new (config);
 dafka_consumer_subscribe (consumer, topic);
 
 dafka_consumer_msg_t *msg = dafka_consumer_msg_new ();
@@ -472,7 +472,7 @@ while (true) {
 }
 
 dafka_consumer_msg_destroy (&msg);
-zactor_destroy (&consumer);
+dafka_consumer_destroy (&consumer);
 zconfig_destroy (&config);
 ```
 

--- a/api/dafka_consumer.api
+++ b/api/dafka_consumer.api
@@ -1,17 +1,40 @@
 <class name = "dafka_consumer">
 
-<actor>
-</actor>
+<constructor>
+    Creates a new dafka consumer client that runs in its own background thread.
+    <argument name = "config" type = "zconfig" />
+</constructor>
 
-<method name = "subscribe" singleton = "1">
-    <argument name = "self" type = "zactor" />
+<destructor>
+    Destroys an instance of dafka consumer client by gracefully stopping its
+    background thread.
+</destructor>
+
+<method name = "subscribe">
+    Subscribe to a given topic.
     <argument name = "subject" type = "string" />
     <return type = "integer" />
 </method>
 
-<method name = "address" singleton = "1">
-    <argument name = "self" type = "zactor" />
+<method name = "unsubscribe">
+    Unsubscribe from a topic currently subscribed to.
+    <argument name = "subject" type = "string" />
+    <return type = "integer" />
+</method>
+
+<method name = "address">
+    Returns the address of the consumer instance.
     <return type = "string" />
+</method>
+
+<method name = "subscription">
+    Get the current subscription as list of strings.
+    <return type = "zlist" />
+</method>
+
+<method name = "record_source">
+    Returns the internal record source socket.
+    <return type = "zsock" />
 </method>
 
 </class>

--- a/api/dafka_consumer_msg.api
+++ b/api/dafka_consumer_msg.api
@@ -34,7 +34,7 @@
     <method name = "recv">
         Receive a message from a consumer actor.
         Return 0 on success and -1 on error.
-        <argument type = "zactor" name = "consumer" />
+        <argument type = "dafka_consumer" name = "consumer" />
         <return type = "integer" />
     </method>
 

--- a/include/dafka.h
+++ b/include/dafka.h
@@ -20,6 +20,11 @@
 //  Add your own public definitions here, if you need them
 
 typedef struct {
+    zsock_t *record_sink;
+    zconfig_t *config;
+} dafka_consumer_args_t;
+
+typedef struct {
     const char *topic;
     zconfig_t *config;
 } dafka_producer_args_t;

--- a/include/dafka_consumer.h
+++ b/include/dafka_consumer.h
@@ -23,17 +23,34 @@ extern "C" {
 //  @interface
 //  This is a stable class, and may not change except for emergencies. It
 //  is provided in stable builds.
-//
+//  Creates a new dafka consumer client that runs in its own background thread.
+DAFKA_EXPORT dafka_consumer_t *
+    dafka_consumer_new (zconfig_t *config);
+
+//  Destroys an instance of dafka consumer client by gracefully stopping its
+//  background thread.
 DAFKA_EXPORT void
-    dafka_consumer (zsock_t *pipe, void *args);
+    dafka_consumer_destroy (dafka_consumer_t **self_p);
 
-//
+//  Subscribe to a given topic.
 DAFKA_EXPORT int
-    dafka_consumer_subscribe (zactor_t *self, const char *subject);
+    dafka_consumer_subscribe (dafka_consumer_t *self, const char *subject);
 
-//
+//  Unsubscribe from a topic currently subscribed to.
+DAFKA_EXPORT int
+    dafka_consumer_unsubscribe (dafka_consumer_t *self, const char *subject);
+
+//  Returns the address of the consumer instance.
 DAFKA_EXPORT const char *
-    dafka_consumer_address (zactor_t *self);
+    dafka_consumer_address (dafka_consumer_t *self);
+
+//  Get the current subscription as list of strings.
+DAFKA_EXPORT zlist_t *
+    dafka_consumer_subscription (dafka_consumer_t *self);
+
+//  Returns the internal record source socket.
+DAFKA_EXPORT zsock_t *
+    dafka_consumer_record_source (dafka_consumer_t *self);
 
 //  Self test of this class.
 DAFKA_EXPORT void

--- a/include/dafka_consumer_msg.h
+++ b/include/dafka_consumer_msg.h
@@ -56,7 +56,7 @@ DAFKA_EXPORT zframe_t *
 //  Receive a message from a consumer actor.
 //  Return 0 on success and -1 on error.
 DAFKA_EXPORT int
-    dafka_consumer_msg_recv (dafka_consumer_msg_t *self, zactor_t *consumer);
+    dafka_consumer_msg_recv (dafka_consumer_msg_t *self, dafka_consumer_t *consumer);
 
 //  Return frame data copied into freshly allocated string
 //  Caller must free string when finished with it.

--- a/src/dafka_console_consumer.c
+++ b/src/dafka_console_consumer.c
@@ -54,7 +54,7 @@ int main (int argc, char *argv [])
 
     const char *topic = zargs_first (args);
 
-    zactor_t *consumer = zactor_new (dafka_consumer, config);
+    dafka_consumer_t *consumer = dafka_consumer_new (config);
     assert (consumer);
 
     // Give time until connected to pubs and stores
@@ -77,7 +77,7 @@ int main (int argc, char *argv [])
     }
 
     dafka_consumer_msg_destroy (&msg);
-    zactor_destroy (&consumer);
+    dafka_consumer_destroy (&consumer);
     zconfig_destroy (&config);
     zargs_destroy (&args);
 

--- a/src/dafka_consumer_msg.c
+++ b/src/dafka_consumer_msg.c
@@ -112,25 +112,27 @@ dafka_consumer_msg_get_content (dafka_consumer_msg_t *self) {
 //  Receive a msg from a consumer actor.
 //  Return 0 on success and -1 on error.
 DAFKA_EXPORT int
-dafka_consumer_msg_recv (dafka_consumer_msg_t *self, zactor_t * consumer) {
+dafka_consumer_msg_recv (dafka_consumer_msg_t *self, dafka_consumer_t * consumer) {
     assert (self);
+    assert (consumer);
+    zsock_t *record_source = dafka_consumer_record_source (consumer);
 
     zmq_msg_t msg;
     zmq_msg_init (&msg);
 
-    int count = zmq_msg_recv (&msg, zsock_resolve (consumer), 0);
+    int count = zmq_msg_recv (&msg, zsock_resolve (record_source), 0);
     if (count < 0)
         return -1;
 
     memcpy (self->subject, zmq_msg_data (&msg), count);
     self->subject[count] = '\0';
 
-    count = zmq_msg_recv (&msg, zsock_resolve (consumer), 0);
+    count = zmq_msg_recv (&msg, zsock_resolve (record_source), 0);
     memcpy (self->address, zmq_msg_data (&msg), count);
     self->address[count] = '\0';
 
     zframe_destroy (&self->content);
-    self->content = zframe_recv(consumer);
+    self->content = zframe_recv (record_source);
 
     return 0;
 }

--- a/src/dafka_consumer_step_defs.c
+++ b/src/dafka_consumer_step_defs.c
@@ -20,7 +20,7 @@ struct _dafka_consumer_state {
     zconfig_t *config;
     zactor_t *tower;
     zactor_t *test_peer;
-    zactor_t *consumer;
+    dafka_consumer_t *consumer;
 };
 
 dafka_consumer_state_t *
@@ -67,7 +67,7 @@ dafka_consumer_state_destroy (dafka_consumer_state_t **self_p)
         //  Free class properties
         zactor_destroy (&self->tower);
         zactor_destroy (&self->test_peer);
-        zactor_destroy (&self->consumer);
+        dafka_consumer_destroy (&self->consumer);
         zconfig_destroy (&self->config);
         //  Free object itself
         free (self);
@@ -84,7 +84,7 @@ given_a_dafka_consumer_with_offset_reset (cucumber_step_def_t *self, void *state
 
     zconfig_put (state->config, "consumer/offset/reset", offset_reset);
 
-    state->consumer = zactor_new (dafka_consumer, state->config);
+    state->consumer = dafka_consumer_new (state->config);
     assert (state->consumer);
     zclock_sleep (250); // Make sure consumer is connected to test_peer before continuing
 }

--- a/src/dafka_perf_consumer.c
+++ b/src/dafka_perf_consumer.c
@@ -57,7 +57,7 @@ int main (int argc, char *argv [])
     int size = atoi (zargs_next (args));
 
     // Creating the consumer
-    zactor_t *consumer = zactor_new (dafka_consumer, config);
+    dafka_consumer_t *consumer = dafka_consumer_new (config);
     dafka_consumer_subscribe (consumer, "$STORE_PERF");
 
     dafka_consumer_msg_t *msg = dafka_consumer_msg_new ();
@@ -85,7 +85,7 @@ int main (int argc, char *argv [])
     printf ("mean throughput: %.3f [Mb/s]\n", megabits);
 
     dafka_consumer_msg_destroy (&msg);
-    zactor_destroy (&consumer);
+    dafka_consumer_destroy (&consumer);
     zargs_destroy (&args);
     zconfig_destroy (&config);
 

--- a/src/dafka_store.c
+++ b/src/dafka_store.c
@@ -200,7 +200,7 @@ dafka_store_test (bool verbose) {
     zactor_destroy (&producer);
 
     // Starting a consumer and check that consumer recv all 3 messages
-    zactor_t *consumer = zactor_new (dafka_consumer, config);
+    dafka_consumer_t *consumer = dafka_consumer_new (config);
     dafka_consumer_subscribe (consumer, "TEST");
 
     dafka_consumer_msg_t *c_msg = dafka_consumer_msg_new ();
@@ -214,7 +214,7 @@ dafka_store_test (bool verbose) {
     assert (dafka_consumer_msg_streq (c_msg, "3"));
 
     dafka_consumer_msg_destroy (&c_msg);
-    zactor_destroy (&consumer);
+    dafka_consumer_destroy (&consumer);
     dafka_producer_msg_destroy (&p_msg);
     zactor_destroy (&store);
     zactor_destroy (&tower);


### PR DESCRIPTION
In the previous consumer implementation both synchronous commands and
asynchronous records where send through the same actor pipe. While
executing a command e.g. 'get address' the answer could have been
a previously received but not yet read consumer record.

Solution: Separate the commands from the consumer records by sending
them through different socket channels.