### PR TITLE
Problem: Unable to register custom socket as message sink

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -457,7 +457,8 @@ To consume this message we constuct a dafka consumer, let it subscribe to topic 
 zconfig_t *config = zconfig_new ("root", NULL);
 const char *topic = "hello";
 
-dafka_consumer_t *consumer = dafka_consumer_new (config);
+dafka_consumer_args_t args = { .config = config };
+dafka_consumer_t *consumer = dafka_consumer_new (&args);
 dafka_consumer_subscribe (consumer, topic);
 
 dafka_consumer_msg_t *msg = dafka_consumer_msg_new ();

--- a/api/dafka_consumer.api
+++ b/api/dafka_consumer.api
@@ -2,7 +2,26 @@
 
 <constructor>
     Creates a new dafka consumer client that runs in its own background thread.
-    <argument name = "config" type = "zconfig" />
+
+    The args parameter consists of configuration and record sink.
+
+    If a record sink is provided this socket will be used the send the consumer
+    messages to.
+
+    The configuration argument takes settings for both the consumer and the
+    beacon, see below.
+
+    Consumer configuration:
+      * consumer/offset/reset = earliest|latest (default: latest)
+      * consumer/high_watermark (default: 1.000.000)
+      * consumer/verbose = 0|1 (default: 0 -> false)
+
+    Beacon configuration:
+      * beacon/interval (default: 1000) in ms
+      * beacon/verbose = 0|1 (default: 0 -> false)
+      * beacon/sub_address (default: tcp://127.0.0.1:5556)
+      * beacon/pub_address (default: tcp://127.0.0.1:5557)
+    <argument name = "args" type = "dafka_consumer_args" />
 </constructor>
 
 <destructor>

--- a/api/dafka_consumer_msg.api
+++ b/api/dafka_consumer_msg.api
@@ -38,6 +38,13 @@
         <return type = "integer" />
     </method>
 
+    <method name = "recv from socket">
+        Receive a message from a custom socket.
+        Return 0 on success and -1 on error.
+        <argument type = "zsock" name = "socket" />
+        <return type = "integer" />
+    </method>
+
     <method name = "strdup">
         Return frame data copied into freshly allocated string
         Caller must free string when finished with it.

--- a/include/dafka.h
+++ b/include/dafka.h
@@ -20,11 +20,6 @@
 //  Add your own public definitions here, if you need them
 
 typedef struct {
-    zsock_t *record_sink;
-    zconfig_t *config;
-} dafka_consumer_args_t;
-
-typedef struct {
     const char *topic;
     zconfig_t *config;
 } dafka_producer_args_t;

--- a/include/dafka_consumer.h
+++ b/include/dafka_consumer.h
@@ -24,8 +24,27 @@ extern "C" {
 //  This is a stable class, and may not change except for emergencies. It
 //  is provided in stable builds.
 //  Creates a new dafka consumer client that runs in its own background thread.
+//
+//  The args parameter consists of configuration and record sink.
+//
+//  If a record sink is provided this socket will be used the send the consumer
+//  messages to.
+//
+//  The configuration argument takes settings for both the consumer and the
+//  beacon, see below.
+//
+//  Consumer configuration:
+//    * consumer/offset/reset = earliest|latest (default: latest)
+//    * consumer/high_watermark (default: 1.000.000)
+//    * consumer/verbose = 0|1 (default: 0 -> false)
+//
+//  Beacon configuration:
+//    * beacon/interval (default: 1000) in ms
+//    * beacon/verbose = 0|1 (default: 0 -> false)
+//    * beacon/sub_address (default: tcp://127.0.0.1:5556)
+//    * beacon/pub_address (default: tcp://127.0.0.1:5557)
 DAFKA_EXPORT dafka_consumer_t *
-    dafka_consumer_new (zconfig_t *config);
+    dafka_consumer_new (dafka_consumer_args_t *args);
 
 //  Destroys an instance of dafka consumer client by gracefully stopping its
 //  background thread.

--- a/include/dafka_consumer_msg.h
+++ b/include/dafka_consumer_msg.h
@@ -58,6 +58,11 @@ DAFKA_EXPORT zframe_t *
 DAFKA_EXPORT int
     dafka_consumer_msg_recv (dafka_consumer_msg_t *self, dafka_consumer_t *consumer);
 
+//  Receive a message from a custom socket.
+//  Return 0 on success and -1 on error.
+DAFKA_EXPORT int
+    dafka_consumer_msg_recv_from_socket (dafka_consumer_msg_t *self, zsock_t *socket);
+
 //  Return frame data copied into freshly allocated string
 //  Caller must free string when finished with it.
 //  Caller owns return value and must destroy it when done.

--- a/include/dafka_library.h
+++ b/include/dafka_library.h
@@ -81,6 +81,10 @@ typedef struct _dafka_tower_t dafka_tower_t;
 typedef struct _dafka_store_t dafka_store_t;
 #define DAFKA_STORE_T_DEFINED
 
+typedef struct {
+    zconfig_t *config;
+    zsock_t *record_sink;
+} dafka_consumer_args_t;
 
 //  Public classes, each with its own header file
 #include "dafka_consumer_msg.h"

--- a/src/dafka_console_consumer.c
+++ b/src/dafka_console_consumer.c
@@ -54,7 +54,8 @@ int main (int argc, char *argv [])
 
     const char *topic = zargs_first (args);
 
-    dafka_consumer_t *consumer = dafka_consumer_new (config);
+    dafka_consumer_args_t consumer_args = { .config = config };
+    dafka_consumer_t *consumer = dafka_consumer_new (&consumer_args);
     assert (consumer);
 
     // Give time until connected to pubs and stores

--- a/src/dafka_consumer_step_defs.c
+++ b/src/dafka_consumer_step_defs.c
@@ -84,7 +84,8 @@ given_a_dafka_consumer_with_offset_reset (cucumber_step_def_t *self, void *state
 
     zconfig_put (state->config, "consumer/offset/reset", offset_reset);
 
-    state->consumer = dafka_consumer_new (state->config);
+    dafka_consumer_args_t args = { .config = state->config };
+    state->consumer = dafka_consumer_new (&args);
     assert (state->consumer);
     zclock_sleep (250); // Make sure consumer is connected to test_peer before continuing
 }

--- a/src/dafka_perf_consumer.c
+++ b/src/dafka_perf_consumer.c
@@ -57,7 +57,8 @@ int main (int argc, char *argv [])
     int size = atoi (zargs_next (args));
 
     // Creating the consumer
-    dafka_consumer_t *consumer = dafka_consumer_new (config);
+    dafka_consumer_args_t consumer_args = { .config = config };
+    dafka_consumer_t *consumer = dafka_consumer_new (&consumer_args);
     dafka_consumer_subscribe (consumer, "$STORE_PERF");
 
     dafka_consumer_msg_t *msg = dafka_consumer_msg_new ();

--- a/src/dafka_store.c
+++ b/src/dafka_store.c
@@ -200,7 +200,8 @@ dafka_store_test (bool verbose) {
     zactor_destroy (&producer);
 
     // Starting a consumer and check that consumer recv all 3 messages
-    dafka_consumer_t *consumer = dafka_consumer_new (config);
+    dafka_consumer_args_t consumer_args = { .config = config };
+    dafka_consumer_t *consumer = dafka_consumer_new (&consumer_args);
     dafka_consumer_subscribe (consumer, "TEST");
 
     dafka_consumer_msg_t *c_msg = dafka_consumer_msg_new ();


### PR DESCRIPTION
Solution: Change the API of dafka_consumer_new to take a
dafka_consumer_args_t struct instead of a zconfig_t.